### PR TITLE
Cell indices got reversed for point queries

### DIFF
--- a/timeseries/app/routers/datasets.py
+++ b/timeseries/app/routers/datasets.py
@@ -83,7 +83,7 @@ class Point(geompyd.Point):
         if not box.covers(point):
             raise SelectedAreaOutOfBoundsError('selected area is not covered by the dataset region')
         logger.info('extracting point: %s', self)
-        px, py = dataset.index(self.coordinates[0], self.coordinates[1])
+        py, px = dataset.index(self.coordinates[0], self.coordinates[1])
         logging.info('indices: %s', (px, py))
         data = dataset.read(list(band_range), window=Window(px, py, 1, 1), out_dtype=np.float64).flatten()
         data[np.equal(data, dataset.nodata)] = np.nan


### PR DESCRIPTION
Pixel extraction was returning an incorrect time series. The rasterio Dataset.index() function returns row and column indices, in that order, but the Window function expects column and row indices. Line 86 had them reversed.